### PR TITLE
Fix gradio passing overrides to tts.py

### DIFF
--- a/gradio_tts_app.py
+++ b/gradio_tts_app.py
@@ -37,6 +37,7 @@ def load_model():
 
 def generate(text, audio_prompt_path, exaggeration, temperature, seed_num,
              #cfgw,
+             diffusion_steps,
              min_p, top_p, repetition_penalty):
     if seed_num != 0:
         set_seed(int(seed_num))
@@ -56,6 +57,7 @@ def generate(text, audio_prompt_path, exaggeration, temperature, seed_num,
         exaggeration=exaggeration,
         temperature=temperature,
         # cfg_weight=cfgw,
+        diffusion_steps=diffusion_steps,
         min_p=min_p,
         top_p=top_p,
         repetition_penalty=repetition_penalty,
@@ -78,6 +80,7 @@ with gr.Blocks() as demo:
 
             with gr.Accordion("More options", open=False):
                 seed_num = gr.Number(value=0, label="Random seed (0 for random)")
+                diffusion_steps = gr.Slider(1, 15, step=1, label="Diffusion Steps (more = slower and higher quality)", value=10)
                 temp = gr.Slider(0.05, 5, step=.05, label="temperature", value=.8)
                 min_p = gr.Slider(0.00, 1.00, step=0.01, label="min_p || Newer Sampler. Recommend 0.02 > 0.1. Handles Higher Temperatures better. 0.00 Disables", value=0.05)
                 top_p = gr.Slider(0.00, 1.00, step=0.01, label="top_p || Original Sampler. 1.0 Disables(recommended). Original 0.8", value=1.00)
@@ -97,6 +100,7 @@ with gr.Blocks() as demo:
             temp,
             seed_num,
             #cfg_weight,
+            diffusion_steps,
             min_p,
             top_p,
             repetition_penalty,

--- a/src/chatterbox_vllm/tts.py
+++ b/src/chatterbox_vllm/tts.py
@@ -83,7 +83,7 @@ class ChatterboxTTS:
         return S3GEN_SR
 
     @classmethod
-    def from_local(cls, ckpt_dir: str, target_device: str = "cuda", 
+    def from_local(cls, ckpt_dir: str | Path, target_device: str = "cuda", 
                    max_model_len: int = 1000, compile: bool = False,
                    max_batch_size: int = 10,
 
@@ -120,16 +120,17 @@ class ChatterboxTTS:
 
         print(f"Giving vLLM {vllm_memory_percent * 100:.2f}% of GPU memory ({vllm_memory_needed / 1024**2:.2f} MB)")
 
-        t3 = LLM(
-            model=f"./t3-model",
-            task="generate",
-            tokenizer="EnTokenizer",
-            tokenizer_mode="custom",
-            max_model_len=max_model_len,
-            gpu_memory_utilization=vllm_memory_percent,
-            enforce_eager=not compile,
-            **kwargs,
-        )
+        base_vllm_kwargs = {
+            "model": "./t3-model",
+            "task": "generate",
+            "tokenizer": "EnTokenizer",
+            "tokenizer_mode": "custom",
+            "gpu_memory_utilization": vllm_memory_percent,
+            "enforce_eager": not compile,
+            "max_model_len": max_model_len,
+        }
+
+        t3 = LLM(**{**base_vllm_kwargs, **kwargs})
 
         ve = VoiceEncoder()
         ve.load_state_dict(load_file(ckpt_dir / "ve.safetensors"))


### PR DESCRIPTION
@randombk This vLLM version is incredible! I'm getting like 16-18x speedup in batch mode! Thank you so much for making it! I have no idea how you did it, but it's amazing!

* Fix gradio passing overrides to tts.py
* Add diffusion steps to gradio with default 10

I found the audio quality of the vLLM to be appreciably worse than the original and went hunting for the reason. I saw the diffusion steps were set down and set them up and that fixed it! So I'd recommend defaulting to 10. vLLM is still loads faster than the original with 10 steps, so I think letting people manually set down the quality for even more speed is better.

Also fixes errors like
```
  File "/home/david/chatterbox-vllm/gradio_tts_app.py", line 29, in load_model
    global_model = ChatterboxTTS.from_pretrained(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/chatterbox-vllm/src/chatterbox_vllm/tts.py", line 165, in from_pretrained
    return cls.from_local(Path(local_path).parent, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/chatterbox-vllm/src/chatterbox_vllm/tts.py", line 123, in from_local
    t3 = LLM(
         ^^^^
TypeError: vllm.entrypoints.llm.LLM() got multiple values for keyword argument 'gpu_memory_utilization'
```